### PR TITLE
Add tox.ini. Fix python 3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__
 /venv
 /dist
 MANIFEST
+.tox

--- a/term2048/board.py
+++ b/term2048/board.py
@@ -1,8 +1,14 @@
 # -*- coding: UTF-8 -*-
-
 import random
 
-class Board():
+# PY3 compat
+try:
+    xrange
+except NameError:
+    xrange = range
+
+
+class Board(object):
     """
     A 2048 board
     """

--- a/term2048/game.py
+++ b/term2048/game.py
@@ -1,13 +1,25 @@
 # -*- coding: UTF-8 -*-
+from __future__ import print_function
 
 import os
 import os.path
-import keypress
-from board import Board
+
 from colorama import init, Fore
+
+from term2048 import keypress
+from term2048.board import Board
+
+# PY3 compat
+try:
+    xrange
+except NameError:
+    xrange = range
+
+
 init(autoreset=True)
 
-class Game:
+
+class Game(object):
     """
     A 2048 game
     """
@@ -89,7 +101,7 @@ class Game:
         """
         while True:
             os.system(Game.__clear)
-            print self.__str__(margins={'left':4, 'top':4, 'bottom':4})
+            print(self.__str__(margins={'left':4, 'top':4, 'bottom':4}))
             if self.board.won() or not self.board.canMove():
                 break
             try:
@@ -102,7 +114,7 @@ class Game:
                 self.best_score = self.score
 
         self.saveBestScore()
-        print 'You won!' if self.board.won() else 'Game Over'
+        print('You won!' if self.board.won() else 'Game Over')
 
     def getCellStr(self, x, y):
         """

--- a/term2048/keypress.py
+++ b/term2048/keypress.py
@@ -17,6 +17,7 @@ __old = termios.tcgetattr(__fd)
 # right: 27 91 67
 UP, DOWN, RIGHT, LEFT = 65, 66, 67, 68
 
+
 def getKey():
     """Return a key pressed by the user"""
     try:
@@ -26,6 +27,7 @@ def getKey():
         return ord(ch)
     finally:
         termios.tcsetattr(__fd, termios.TCSADRAIN, __old)
+
 
 def getArrowKey():
     """same as getKey, but assuming that the user pressed an arrow key"""

--- a/term2048/ui.py
+++ b/term2048/ui.py
@@ -1,6 +1,7 @@
 # -*- coding: UTF-8 -*-
 
-from game import Game
+from term2048.game import Game
+
 
 def start_game(**kws):
     """start a new game"""

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,8 +1,12 @@
 # -*- coding: UTF-8 -*-
+import sys
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 from os.path import dirname
-import sys
-import unittest
 
 if __name__ == '__main__':
     here = dirname(__file__)

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -1,7 +1,17 @@
 # -*- coding: UTF-8 -*-
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
-import unittest
 from term2048.board import Board
+
+# PY3 compat
+try:
+    xrange
+except NameError:
+    xrange = range
+
 
 class TestBoard(unittest.TestCase):
 

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -1,7 +1,10 @@
 # -*- coding: UTF-8 -*-
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 from colorama import Fore
-import unittest
 from term2048.board import Board
 from term2048.game import Game
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,14 @@
+[tox]
+envlist = py26, py27, py32, py33
+downloadcache = {toxworkdir}/_download/
+
+[testenv]
+sitepackages = False
+commands =
+    {envpython} {toxinidir}/tests/test.py
+
+[testenv:py26]
+deps = unittest2
+
+[testenv:py27]
+deps = unittest2


### PR DESCRIPTION
I thought it might be helpful to have a tox.ini file for testing multiple python versions. I also noticed some various failures for python 2.6 as well as compatibility for python 3. I've included the changes for this as well.
