### PR TITLE
addTile: Make 4 only have 10% chance to spawn

### DIFF
--- a/term2048/board.py
+++ b/term2048/board.py
@@ -60,12 +60,12 @@ class Board(object):
         """
         return len(self.getEmptyCells()) == 0
 
-    def addTile(self, value=None, choices=[2, 4]):
+    def addTile(self, value=None, choices=([2]*9+[4])):
         """
         add a random tile in an empty cell
           value: value of the tile to add.
           choices: a list of possible choices for the value of the tile.
-                   default is [2, 4].
+                   default is [2, 2, 2, 2, 2, 2, 2, 2, 2, 4].
         """
         if value:
             choices = [value]


### PR DESCRIPTION
The original game code for adding a new tile is

```
var value = Math.random() < 0.9 ? 2 : 4;
```

That is: 90% of new tiles are 2, 10% are 4s. This pull request changes the addTile function to this behavoir
