### PR TITLE
add: link to replit run

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,1 +1,2 @@
-language = "python3"\nrun = "python setup.py install && term2048"\n
+language = "python3"
+run = "python setup.py install && term2048"

--- a/.replit
+++ b/.replit
@@ -1,0 +1,1 @@
+language = "python3"\nrun = "python setup.py install && term2048"\n

--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,10 @@ term2048
    :target: https://coveralls.io/r/bfontaine/term2048?branch=master
    :alt: Coverage status
 
+.. image:: http://repl.it/badge/github/bfontaine/term2048
+   :target: https://repl.it/github/bfontaine/term2048
+   :alt: run on repl.it
+
 .. image:: https://img.shields.io/pypi/v/term2048.svg
    :target: https://pypi.python.org/pypi/term2048
    :alt: Pypi package


### PR DESCRIPTION
i think it would be pretty cool to let people see how this code works (and edit the program) right in their browser, without any manual downloads or installation. i'm thinking we can add a 'run on repl.it' button, which redirects to something like [this](https://repl.it/@eankeen/run-term2048):

![image](https://i.imgur.com/2xa327B.png)
