### PR TITLE
Add anti-matter tiles, blocker tiles, and rectangular boards

### DIFF
--- a/term2048/board.py
+++ b/term2048/board.py
@@ -21,20 +21,54 @@ class Board(object):
     UP, DOWN, LEFT, RIGHT, PAUSE = 1, 2, 3, 4, 5
 
     GOAL = 2048
+    WIDTH = 8
+    HEIGHT = 4
+    # legacy square-size constant kept for backward compatibility
     SIZE = 4
 
-    def __init__(self, goal=GOAL, size=SIZE, **_kwargs):
-        self.__size = size
-        self.__size_range = xrange(0, self.__size)
+    # sentinel for an immovable blocker tile
+    BLOCKER = 'X'
+
+    # number of blocker tiles placed at the start of a game
+    BLOCKER_COUNT = 2
+
+    # probability that a freshly spawned tile is anti-matter (negative)
+    ANTIMATTER_CHANCE = 0.2
+
+    def __init__(self, goal=GOAL, width=None, height=None, size=None,
+                 blockers=BLOCKER_COUNT, antimatter_chance=ANTIMATTER_CHANCE,
+                 **_kwargs):
+        if size is not None:
+            # legacy square-board argument
+            self.__width = size
+            self.__height = size
+        else:
+            self.__width = width if width is not None else Board.WIDTH
+            self.__height = height if height is not None else Board.HEIGHT
+        self.__x_range = xrange(0, self.__width)
+        self.__y_range = xrange(0, self.__height)
         self.__goal = goal
         self.__won = False
-        self.cells = [[0]*self.__size for _ in xrange(self.__size)]
+        self.__antimatter_chance = antimatter_chance
+        self.cells = [[0] * self.__width for _ in xrange(self.__height)]
+
+        for _ in xrange(blockers):
+            self.addBlocker()
+
         self.addTile()
         self.addTile()
 
+    def width(self):
+        """return the board width (number of columns)"""
+        return self.__width
+
+    def height(self):
+        """return the board height (number of rows)"""
+        return self.__height
+
     def size(self):
-        """return the board size"""
-        return self.__size
+        """return the board size (legacy, assumes a square board)"""
+        return self.__width
 
     def goal(self):
         """return the board goal"""
@@ -53,12 +87,19 @@ class Board(object):
         if not self.filled():
             return True
 
-        for y in self.__size_range:
-            for x in self.__size_range:
+        for y in self.__y_range:
+            for x in self.__x_range:
                 c = self.getCell(x, y)
-                if (x < self.__size-1 and c == self.getCell(x+1, y)) \
-                   or (y < self.__size-1 and c == self.getCell(x, y+1)):
-                    return True
+                if c == Board.BLOCKER:
+                    continue
+                if x < self.__width - 1:
+                    r = self.getCell(x + 1, y)
+                    if r != Board.BLOCKER and (c == r or c == -r):
+                        return True
+                if y < self.__height - 1:
+                    d = self.getCell(x, y + 1)
+                    if d != Board.BLOCKER and (c == d or c == -d):
+                        return True
 
         return False
 
@@ -68,6 +109,26 @@ class Board(object):
         """
         return len(self.getEmptyCells()) == 0
 
+    def addBlocker(self):
+        """
+        place a permanent blocker tile on a random empty cell that does not
+        share a row or a column with any existing blocker, so that blockers
+        can never line up and wall off a section of the board
+        """
+        used_cols = set()
+        used_rows = set()
+        for y in self.__y_range:
+            for x in self.__x_range:
+                if self.getCell(x, y) == Board.BLOCKER:
+                    used_cols.add(x)
+                    used_rows.add(y)
+
+        candidates = [(x, y) for (x, y) in self.getEmptyCells()
+                      if x not in used_cols and y not in used_rows]
+        if candidates:
+            x, y = random.choice(candidates)
+            self.setCell(x, y, Board.BLOCKER)
+
     def addTile(self, value=None, choices=None):
         """
         add a random tile in an empty cell
@@ -75,6 +136,9 @@ class Board(object):
           choices: a list of possible choices for the value of the tile. if
                    ``None`` (the default), it uses
                    ``[2, 2, 2, 2, 2, 2, 2, 2, 2, 4]``.
+
+        There is an ``antimatter_chance`` probability that the spawned tile
+        is negative (anti-matter).
         """
         if choices is None:
             choices = [2] * 9 + [4]
@@ -83,6 +147,8 @@ class Board(object):
             choices = [value]
 
         v = random.choice(choices)
+        if random.random() < self.__antimatter_chance:
+            v = -v
         empty = self.getEmptyCells()
         if empty:
             x, y = random.choice(empty)
@@ -102,7 +168,7 @@ class Board(object):
 
     def getCol(self, x):
         """return the x-th column, starting at 0"""
-        return [self.getCell(x, i) for i in self.__size_range]
+        return [self.getCell(x, i) for i in self.__y_range]
 
     def setLine(self, y, l):
         """set the y-th line, starting at 0"""
@@ -110,75 +176,113 @@ class Board(object):
 
     def setCol(self, x, l):
         """set the x-th column, starting at 0"""
-        for i in xrange(0, self.__size):
+        for i in xrange(0, self.__height):
             self.setCell(x, i, l[i])
 
     def getEmptyCells(self):
         """return a (x, y) pair for each empty cell"""
         return [(x, y)
-                for x in self.__size_range
-                for y in self.__size_range if self.getCell(x, y) == 0]
+                for x in self.__x_range
+                for y in self.__y_range if self.getCell(x, y) == 0]
 
-    def __collapseLineOrCol(self, line, d):
+    def __collapseSegment(self, line, d):
         """
-        Merge tiles in a line or column according to a direction and return a
-        tuple with the new line and the score for the move on this line
+        Merge tiles in a blocker-free segment according to a direction and
+        return a tuple with the new line and the score for the move on this
+        segment.
+
+        Two equal tiles merge into their double (this holds for negative
+        tiles too, e.g. -2 and -2 become -4). A positive tile and its exact
+        negative counterpart annihilate into an empty cell and score 0.
         """
+        n = len(line)
         if (d == Board.LEFT or d == Board.UP):
             inc = 1
-            rg = xrange(0, self.__size-1, inc)
+            rg = xrange(0, n - 1, inc)
         else:
             inc = -1
-            rg = xrange(self.__size-1, 0, inc)
+            rg = xrange(n - 1, 0, inc)
 
         pts = 0
         for i in rg:
             if line[i] == 0:
                 continue
-            if line[i] == line[i+inc]:
-                v = line[i]*2
+            if line[i] == line[i + inc]:
+                v = line[i] * 2
                 if v == self.__goal:
                     self.__won = True
 
                 line[i] = v
-                line[i+inc] = 0
-                pts += v
+                line[i + inc] = 0
+                pts += abs(v)
+            elif line[i] == -line[i + inc]:
+                # matter / anti-matter annihilation: both tiles vanish, but
+                # award the absolute value of the destroyed pair since the
+                # player spent moves building them up
+                pts += abs(line[i])
+                line[i] = 0
+                line[i + inc] = 0
 
         return (line, pts)
 
-    def __moveLineOrCol(self, line, d):
+    def __moveSegment(self, line, d):
         """
-        Move a line or column to a given direction (d)
+        Move a blocker-free segment to a given direction (d)
         """
         nl = [c for c in line if c != 0]
         if d == Board.UP or d == Board.LEFT:
-            return nl + [0] * (self.__size - len(nl))
-        return [0] * (self.__size - len(nl)) + nl
+            return nl + [0] * (len(line) - len(nl))
+        return [0] * (len(line) - len(nl)) + nl
+
+    def __processSegment(self, seg, d):
+        """move + collapse + move a single blocker-free segment"""
+        moved = self.__moveSegment(seg, d)
+        collapsed, pts = self.__collapseSegment(moved, d)
+        return self.__moveSegment(collapsed, d), pts
+
+    def __processLineOrCol(self, line, d):
+        """
+        Split a line/column on blocker tiles, process each segment
+        independently (so tiles cannot slide through or merge across a
+        blocker), then stitch the result back together with the blockers in
+        their original positions.
+        """
+        result = []
+        pts = 0
+        seg = []
+        for c in line:
+            if c == Board.BLOCKER:
+                new_seg, p = self.__processSegment(seg, d)
+                result.extend(new_seg)
+                result.append(Board.BLOCKER)
+                pts += p
+                seg = []
+            else:
+                seg.append(c)
+        new_seg, p = self.__processSegment(seg, d)
+        result.extend(new_seg)
+        pts += p
+        return result, pts
 
     def move(self, d, add_tile=True):
         """
         move and return the move score
         """
         if d == Board.LEFT or d == Board.RIGHT:
-            chg, get = self.setLine, self.getLine
+            chg, get, rg = self.setLine, self.getLine, self.__y_range
         elif d == Board.UP or d == Board.DOWN:
-            chg, get = self.setCol, self.getCol
+            chg, get, rg = self.setCol, self.getCol, self.__x_range
         else:
             return 0
 
         moved = False
         score = 0
 
-        for i in self.__size_range:
+        for i in rg:
             # save the original line/col
             origin = get(i)
-            # move it
-            line = self.__moveLineOrCol(origin, d)
-            # merge adjacent tiles
-            collapsed, pts = self.__collapseLineOrCol(line, d)
-            # move it again (for when tiles are merged, because empty cells are
-            # inserted in the middle of the line/col)
-            new = self.__moveLineOrCol(collapsed, d)
+            # move + merge, treating blockers as fixed walls
+            new, pts = self.__processLineOrCol(list(origin), d)
             # set it back in the board
             chg(i, new)
             # did it change?

--- a/term2048/game.py
+++ b/term2048/game.py
@@ -149,11 +149,11 @@ class Game(object):
         """
         save the current game session's score and data for further use
         """
-        size = self.board.SIZE
+        w, h = self.board.width(), self.board.height()
         cells = []
 
-        for i in range(size):
-            for j in range(size):
+        for i in range(h):
+            for j in range(w):
                 cells.append(str(self.board.getCell(j, i)))
 
         score_str = "%s\n%d" % (' '.join(cells), self.score)
@@ -170,7 +170,7 @@ class Game(object):
         restore the saved game score and data
         """
 
-        size = self.board.SIZE
+        w, h = self.board.width(), self.board.height()
 
         try:
             with open(self.store_file, 'r') as f:
@@ -183,10 +183,13 @@ class Game(object):
         score_str_list = score_str.split(' ')
         count = 0
 
-        for i in range(size):
-            for j in range(size):
+        for i in range(h):
+            for j in range(w):
                 value = score_str_list[count]
-                self.board.setCell(j, i, int(value))
+                if value.strip() == Board.BLOCKER:
+                    self.board.setCell(j, i, Board.BLOCKER)
+                else:
+                    self.board.setCell(j, i, int(value))
                 count += 1
 
         return True
@@ -258,25 +261,39 @@ class Game(object):
         """
         c = self.board.getCell(x, y)
 
-        if c == 0:
-            return '.' if self.__azmode else '  .'
+        if c == Board.BLOCKER:
+            if self.__azmode:
+                return Fore.WHITE + Style.BRIGHT + 'X' + Style.RESET_ALL
+            return Fore.WHITE + Style.BRIGHT + '   X' + Style.RESET_ALL
 
-        elif self.__azmode:
+        if c == 0:
+            return '.' if self.__azmode else '   .'
+
+        av = abs(c)
+
+        if self.__azmode:
             az = {}
             for i in range(1, int(math.log(self.board.goal(), 2))):
                 az[2 ** i] = chr(i + 96)
 
-            if c not in az:
+            if av not in az:
                 return '?'
-            s = az[c]
-        elif c == 1024:
-            s = ' 1k'
-        elif c == 2048:
-            s = ' 2k'
+            # uppercase letter denotes an anti-matter tile
+            s = az[av].upper() if c < 0 else az[av]
+        elif av == 1024:
+            s = ' -1k' if c < 0 else '  1k'
+        elif av == 2048:
+            s = ' -2k' if c < 0 else '  2k'
         else:
-            s = '%3d' % c
+            s = '%4d' % c
 
-        return self.__colors.get(c, Fore.RESET) + s + Style.RESET_ALL
+        if c < 0:
+            # anti-matter tiles get a single dedicated color so they stand
+            # out from their positive counterparts
+            color = Fore.RED + Style.BRIGHT
+        else:
+            color = self.__colors.get(av, Fore.RESET)
+        return color + s + Style.RESET_ALL
 
     def boardToString(self, margins=None):
         """
@@ -286,10 +303,11 @@ class Game(object):
             margins = {}
 
         b = self.board
-        rg = range(b.size())
         left = ' '*margins.get('left', 0)
         s = '\n'.join(
-            [left + ' '.join([self.getCellStr(x, y) for x in rg]) for y in rg])
+            [left + ' '.join(
+                [self.getCellStr(x, y) for x in range(b.width())])
+             for y in range(b.height())])
         return s
 
     def __str__(self, margins=None):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -30,8 +30,11 @@ class FakeMsvcrt(object):
 if platform.python_version() < '3.0':
     reload = reload
 else:
-    import imp
-    reload = imp.reload
+    try:
+        from importlib import reload
+    except ImportError:
+        import imp
+        reload = imp.reload
 
 
 # used by sys.exit mocks

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -23,10 +23,17 @@ except NameError:
     xrange = range
 
 
+def _B(**kw):
+    """Board with the classic ruleset (no blockers, no anti-matter)"""
+    kw.setdefault('blockers', 0)
+    kw.setdefault('antimatter_chance', 0)
+    return Board(**kw)
+
+
 class TestBoard(unittest.TestCase):
 
     def setUp(self):
-        self.b = Board()
+        self.b = _B(size=Board.SIZE)
 
     # == init == #
     def test_init_dimensions(self):
@@ -35,13 +42,25 @@ class TestBoard(unittest.TestCase):
         if Board.SIZE > 1:
             self.assertEqual(len(self.b.cells[1]), Board.SIZE)
 
+    def test_init_default_dimensions(self):
+        b = _B()
+        self.assertEqual(b.width(), Board.WIDTH)
+        self.assertEqual(b.height(), Board.HEIGHT)
+        self.assertEqual(len(b.cells), Board.HEIGHT)
+        self.assertEqual(len(b.cells[0]), Board.WIDTH)
+
+    def test_init_rectangular_dimensions(self):
+        b = _B(width=7, height=3)
+        self.assertEqual(b.width(), 7)
+        self.assertEqual(b.height(), 3)
+
     def test_init_dimensions_1(self):
-        b = Board(size=1)
+        b = _B(size=1)
         c = b.cells[0][0]
         self.assertTrue(c in [2, 4])
 
     def test_init_dimensions_3_goal_4(self):
-        b = Board(size=3, goal=4)
+        b = _B(size=3, goal=4)
         self.assertEqual(b.size(), 3)
 
     def test_init_only_two_tiles(self):
@@ -56,6 +75,36 @@ class TestBoard(unittest.TestCase):
 
         self.assertEqual(t, 2)
 
+    def test_init_with_blockers(self):
+        b = _B(size=5, blockers=2)
+        blockers = [(x, y) for y in xrange(5) for x in xrange(5)
+                    if b.getCell(x, y) == Board.BLOCKER]
+        self.assertEqual(len(blockers), 2)
+
+    def test_blockers_never_share_row_or_col(self):
+        for _ in xrange(200):
+            b = _B(width=Board.WIDTH, height=Board.HEIGHT, blockers=2)
+            blockers = [(x, y)
+                        for y in xrange(b.height())
+                        for x in xrange(b.width())
+                        if b.getCell(x, y) == Board.BLOCKER]
+            self.assertEqual(len(blockers), 2)
+            (x1, y1), (x2, y2) = blockers
+            self.assertNotEqual(x1, x2)
+            self.assertNotEqual(y1, y2)
+
+    def test_addBlocker_avoids_existing_row_and_col(self):
+        b = _B(size=3)
+        b.cells = [[0]*3 for _ in xrange(3)]
+        b.setCell(1, 1, Board.BLOCKER)
+        b.addBlocker()
+        blockers = [(x, y) for y in xrange(3) for x in xrange(3)
+                    if b.getCell(x, y) == Board.BLOCKER]
+        self.assertEqual(len(blockers), 2)
+        other = [p for p in blockers if p != (1, 1)][0]
+        self.assertNotEqual(other[0], 1)
+        self.assertNotEqual(other[1], 1)
+
     def test_init_not_won(self):
         self.assertFalse(self.b.won())
 
@@ -65,13 +114,13 @@ class TestBoard(unittest.TestCase):
     # == .size == #
     def test_size(self):
         s = 42
-        b = Board(size=s)
+        b = _B(size=s)
         self.assertEqual(b.size(), s)
 
     # == .goal == #
     def test_goal(self):
         g = 17
-        b = Board(goal=g)
+        b = _B(goal=g)
         self.assertEqual(b.goal(), g)
 
     # == .won == #
@@ -83,21 +132,42 @@ class TestBoard(unittest.TestCase):
 
     # == .canMove == #
     def test_canMove_no_empty_cell(self):
-        b = Board(size=1)
+        b = _B(size=1)
         b.setCell(0, 0, 42)
         self.assertFalse(b.canMove())
 
     def test_canMove_empty_cell(self):
-        b = Board(size=2)
+        b = _B(size=2)
         self.assertTrue(b.canMove())
 
     def test_canMove_no_empty_cell_can_collapse(self):
-        b = Board(size=2)
+        b = _B(size=2)
         b.cells = [
             [2, 2],
             [4, 8]
         ]
         self.assertTrue(b.canMove())
+
+    def test_canMove_annihilation(self):
+        b = _B(size=2)
+        b.cells = [
+            [2, -2],
+            [4, 8]
+        ]
+        self.assertTrue(b.canMove())
+
+    def test_canMove_blocker_blocks_merge(self):
+        b = _B(width=3, height=1)
+        b.cells = [[2, Board.BLOCKER, 2]]
+        self.assertFalse(b.canMove())
+
+    def test_canMove_adjacent_blockers_dont_merge(self):
+        b = _B(size=2)
+        b.cells = [
+            [Board.BLOCKER, Board.BLOCKER],
+            [2, 4]
+        ]
+        self.assertFalse(b.canMove())
 
     # == .filled == #
     def test_filled(self):
@@ -106,10 +176,16 @@ class TestBoard(unittest.TestCase):
 
     # == .addTile == #
     def test_addTile(self):
-        b = Board(size=1)
+        b = _B(size=1)
         b.cells = [[0]]
         b.addTile(value=42)
         self.assertEqual(b.cells[0][0], 42)
+
+    def test_addTile_antimatter(self):
+        b = _B(size=1, antimatter_chance=1.0)
+        b.cells = [[0]]
+        b.addTile(value=42)
+        self.assertEqual(b.cells[0][0], -42)
 
     # == .getCell == #
     def test_getCell(self):
@@ -127,7 +203,7 @@ class TestBoard(unittest.TestCase):
 
     # == .getLine == #
     def test_getLine(self):
-        b = Board(size=4)
+        b = _B(size=4)
         l = [42, 17, 12, 3]
         b.cells = [
             [0]*4,
@@ -140,7 +216,7 @@ class TestBoard(unittest.TestCase):
     # == .getCol == #
     def test_getCol(self):
         s = 4
-        b = Board(size=s)
+        b = _B(size=s)
         l = [42, 17, 12, 3]
         b.cells = [[l[i], 4, 1, 2] for i in xrange(s)]
         self.assertSequenceEqual(b.getCol(0), l)
@@ -164,13 +240,21 @@ class TestBoard(unittest.TestCase):
         self.assertEqual(len(self.b.getEmptyCells()), Board.SIZE**2 - 2)
 
     def test_getEmptyCells_filled(self):
-        b = Board(size=1)
+        b = _B(size=1)
         b.setCell(0, 0, 42)
         self.assertSequenceEqual(b.getEmptyCells(), [])
 
+    def test_getEmptyCells_blocker_not_empty(self):
+        b = _B(size=2)
+        b.cells = [
+            [Board.BLOCKER, 0],
+            [0, 0]
+        ]
+        self.assertEqual(len(b.getEmptyCells()), 3)
+
     # == .move == #
     def test_move_filled(self):
-        b = Board(size=1)
+        b = _B(size=1)
         b.setCell(0, 0, 42)
         b.move(Board.UP)
         self.assertSequenceEqual(b.cells, [[42]])
@@ -182,21 +266,21 @@ class TestBoard(unittest.TestCase):
         self.assertSequenceEqual(b.cells, [[42]])
 
     def test_move_add_tile_if_collapse(self):
-        b = Board(size=2)
+        b = _B(size=2)
         b.cells = [[2, 0],
                    [2, 0]]
         b.move(Board.UP)
         self.assertEqual(len([e for l in b.cells for e in l if e != 0]), 2)
 
     def test_move_add_tile_if_move(self):
-        b = Board(size=2)
+        b = _B(size=2)
         b.cells = [[0, 0],
                    [2, 0]]
         b.move(Board.UP)
         self.assertEqual(len([e for l in b.cells for e in l if e != 0]), 2)
 
     def test_move_dont_add_tile_if_nothing_move(self):
-        b = Board(size=2)
+        b = _B(size=2)
         b.cells = [[2, 0],
                    [0, 0]]
         b.move(Board.UP)
@@ -204,7 +288,7 @@ class TestBoard(unittest.TestCase):
 
     # test for issue #1
     def test_move_dont_add_tile_if_nothing_move2(self):
-        b = Board()
+        b = _B(size=4)
         b.cells = [
             [8, 4, 4, 2],
             [0, 2, 2, 0],
@@ -217,7 +301,7 @@ class TestBoard(unittest.TestCase):
         self.assertEqual(b.getLine(1), [0, 2, 2, 0])
 
     def test_move_collapse(self):
-        b = Board(size=2)
+        b = _B(size=2)
         b.cells = [
             [2, 2],
             [0, 0]
@@ -230,31 +314,31 @@ class TestBoard(unittest.TestCase):
         ])
 
     def test_move_collapse_triplet1(self):
-        b = Board(size=3)
+        b = _B(size=3)
         b.setLine(0, [2, 2, 2])
         b.move(Board.LEFT, add_tile=False)
         self.assertSequenceEqual(b.getLine(0), [4, 2, 0])
 
     def test_move_collapse_triplet2(self):
-        b = Board(size=3)
+        b = _B(size=3)
         b.setLine(0, [2, 2, 2])
         b.move(Board.RIGHT, add_tile=False)
         self.assertSequenceEqual(b.getLine(0), [0, 2, 4])
 
     def test_move_collapse_with_empty_cell_in_between(self):
-        b = Board(size=3)
+        b = _B(size=3)
         b.setLine(0, [2, 0, 2])
         b.move(Board.RIGHT, add_tile=False)
         self.assertSequenceEqual(b.getLine(0), [0, 0, 4])
 
     def test_move_collapse_with_empty_cell_in_between2(self):
-        b = Board(size=3)
+        b = _B(size=3)
         b.setLine(0, [2, 0, 2])
         b.move(Board.LEFT, add_tile=False)
         self.assertSequenceEqual(b.getLine(0), [4, 0, 0])
 
     def test_move_collapse_and_win(self):
-        b = Board(size=2, goal=4)
+        b = _B(size=2, goal=4)
         b.cells = [
             [2, 2],
             [0, 0]
@@ -271,13 +355,13 @@ class TestBoard(unittest.TestCase):
     #   see: https://news.ycombinator.com/item?id=7398249
 
     def test_move_collapse_chain_col(self):
-        b = Board()
+        b = _B(size=4)
         b.setCol(0, [0, 2, 2, 4])
         b.move(Board.DOWN, add_tile=False)
         self.assertSequenceEqual(b.getCol(0), [0, 0, 4, 4])
 
     def test_move_collapse_chain_line_right(self):
-        b = Board()
+        b = _B(size=4)
         b.cells = [
             [0, 2, 2, 4],
             [0]*4,
@@ -288,7 +372,7 @@ class TestBoard(unittest.TestCase):
         self.assertSequenceEqual(b.getLine(0), [0, 0, 4, 4])
 
     def test_move_collapse_chain_line_right2(self):
-        b = Board()
+        b = _B(size=4)
         b.cells = [
             [0, 4, 2, 2],
             [0]*4,
@@ -299,7 +383,7 @@ class TestBoard(unittest.TestCase):
         self.assertSequenceEqual(b.getLine(0), [0, 0, 4, 4])
 
     def test_move_collapse_chain_line_left(self):
-        b = Board()
+        b = _B(size=4)
         b.cells = [
             [0, 2, 2, 4],
             [0]*4,
@@ -310,7 +394,7 @@ class TestBoard(unittest.TestCase):
         self.assertSequenceEqual(b.getLine(0), [4, 4, 0, 0])
 
     def test_move_collapse_chain_four_same_tiles(self):
-        b = Board()
+        b = _B(size=4)
         b.cells = [
             [2, 2, 2, 2],
             [0]*4,
@@ -319,6 +403,71 @@ class TestBoard(unittest.TestCase):
         ]
         self.assertEqual(b.move(Board.LEFT, add_tile=False), 8)
         self.assertSequenceEqual(b.getLine(0), [4, 4, 0, 0])
+
+    # == anti-matter == #
+
+    def test_move_antimatter_merge(self):
+        b = _B(width=3, height=1)
+        b.cells = [[-2, -2, 0]]
+        self.assertEqual(b.move(Board.LEFT, add_tile=False), 4)
+        self.assertSequenceEqual(b.getLine(0), [-4, 0, 0])
+
+    def test_move_annihilation(self):
+        b = _B(width=3, height=1)
+        b.cells = [[4, -4, 0]]
+        self.assertEqual(b.move(Board.LEFT, add_tile=False), 4)
+        self.assertSequenceEqual(b.getLine(0), [0, 0, 0])
+
+    def test_move_annihilation_leaves_rest(self):
+        b = _B(width=4, height=1)
+        b.cells = [[4, -4, 8, 0]]
+        b.move(Board.LEFT, add_tile=False)
+        self.assertSequenceEqual(b.getLine(0), [8, 0, 0, 0])
+
+    def test_move_no_annihilation_mismatch(self):
+        b = _B(width=3, height=1)
+        b.cells = [[4, -2, 0]]
+        b.move(Board.LEFT, add_tile=False)
+        self.assertSequenceEqual(b.getLine(0), [4, -2, 0])
+
+    def test_antimatter_merge_does_not_win(self):
+        b = _B(size=2, goal=4)
+        b.cells = [
+            [-2, -2],
+            [8, 16]
+        ]
+        b.move(Board.LEFT, add_tile=False)
+        self.assertFalse(b.won())
+
+    # == blockers == #
+
+    def test_move_blocker_is_immovable(self):
+        X = Board.BLOCKER
+        b = _B(width=4, height=1)
+        b.cells = [[2, X, 0, 4]]
+        b.move(Board.LEFT, add_tile=False)
+        self.assertSequenceEqual(b.getLine(0), [2, X, 4, 0])
+
+    def test_move_blocker_prevents_merge(self):
+        X = Board.BLOCKER
+        b = _B(width=4, height=1)
+        b.cells = [[2, X, 2, 0]]
+        b.move(Board.LEFT, add_tile=False)
+        self.assertSequenceEqual(b.getLine(0), [2, X, 2, 0])
+
+    def test_move_blocker_segments_independent(self):
+        X = Board.BLOCKER
+        b = _B(width=6, height=1)
+        b.cells = [[2, 2, X, 0, 4, 4]]
+        b.move(Board.RIGHT, add_tile=False)
+        self.assertSequenceEqual(b.getLine(0), [0, 4, X, 0, 0, 8])
+
+    def test_move_blocker_column(self):
+        X = Board.BLOCKER
+        b = _B(width=1, height=4)
+        b.cells = [[0], [2], [X], [2]]
+        b.move(Board.DOWN, add_tile=False)
+        self.assertSequenceEqual(b.getCol(0), [0, 2, X, 2])
 
 
 class TestBoardPy3k(unittest.TestCase):

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -162,7 +162,7 @@ class TestGame(unittest.TestCase):
         g2 = Game(scores_file=None, store_file=store.name)
         g2.board.setCell(0, 0, 16)
         self.assertTrue(g2.restore())
-        self.assertIn(g2.board.getCell(0, 0), [0, 2, 4])
+        self.assertEqual(g2.board.cells, g1.board.cells)
         remove(store.name)
 
     def test_restore_fail_return_false(self):
@@ -266,7 +266,7 @@ class TestGame(unittest.TestCase):
 
     def test_loop_interrupt(self):
         kp._setCtrlC(True)
-        g = Game(goal=4, size=2, scores_file=None)
+        g = Game(goal=4, size=2, blockers=0, scores_file=None)
         self.assertEqual(g.loop(), None)
 
     def test_loop_pause(self):
@@ -292,12 +292,12 @@ class TestGame(unittest.TestCase):
 
     def test_getCellStr_0(self):
         self.b.setCell(0, 0, 0)
-        self.assertEqual(self.g.getCellStr(0, 0), '  .')
+        self.assertEqual(self.g.getCellStr(0, 0), '   .')
 
     def test_getCellStr_unknown_number(self):
         self.b.setCell(0, 0, 42)
         self.assertEqual(self.g.getCellStr(0, 0),
-                         '%s 42%s' % (Fore.RESET, Style.RESET_ALL))
+                         '%s  42%s' % (Fore.RESET, Style.RESET_ALL))
 
     def test_getCellStr_0_azmode(self):
         g = Game(azmode=True)
@@ -307,22 +307,52 @@ class TestGame(unittest.TestCase):
     def test_getCellStr_2(self):
         g = Game()
         g.board.setCell(0, 0, 2)
-        self.assertRegexpMatches(g.getCellStr(0, 0), r'  2\x1b\[0m$')
+        self.assertRegex(g.getCellStr(0, 0), r'   2\x1b\[0m$')
+
+    def test_getCellStr_negative_2(self):
+        g = Game()
+        g.board.setCell(0, 0, -2)
+        self.assertRegex(g.getCellStr(0, 0), r'  -2\x1b\[0m$')
+
+    def test_getCellStr_negative_has_own_color(self):
+        g = Game()
+        g.board.setCell(0, 0, 2)
+        g.board.setCell(1, 0, -2)
+        pos = g.getCellStr(0, 0)
+        neg = g.getCellStr(1, 0)
+        # strip the numeric payload; the color prefix must differ
+        self.assertNotEqual(pos.split('2')[0], neg.split('2')[0])
+        self.assertIn(Fore.RED + Style.BRIGHT, neg)
+
+    def test_getCellStr_blocker(self):
+        g = Game()
+        g.board.setCell(0, 0, Board.BLOCKER)
+        self.assertRegex(g.getCellStr(0, 0), r'   X\x1b\[0m$')
 
     def test_getCellStr_1k(self):
         g = Game()
         g.board.setCell(0, 0, 1024)
-        self.assertRegexpMatches(g.getCellStr(0, 0), r' 1k\x1b\[0m$')
+        self.assertRegex(g.getCellStr(0, 0), r'  1k\x1b\[0m$')
 
     def test_getCellStr_2k(self):
         g = Game()
         g.board.setCell(0, 0, 2048)
-        self.assertRegexpMatches(g.getCellStr(0, 0), r' 2k\x1b\[0m$')
+        self.assertRegex(g.getCellStr(0, 0), r'  2k\x1b\[0m$')
 
     def test_getCellStr_2_azmode(self):
         g = Game(azmode=True)
         g.board.setCell(0, 0, 2)
-        self.assertRegexpMatches(g.getCellStr(0, 0), r'a\x1b\[0m$')
+        self.assertRegex(g.getCellStr(0, 0), r'a\x1b\[0m$')
+
+    def test_getCellStr_negative_2_azmode(self):
+        g = Game(azmode=True)
+        g.board.setCell(0, 0, -2)
+        self.assertRegex(g.getCellStr(0, 0), r'A\x1b\[0m$')
+
+    def test_getCellStr_blocker_azmode(self):
+        g = Game(azmode=True)
+        g.board.setCell(0, 0, Board.BLOCKER)
+        self.assertRegex(g.getCellStr(0, 0), r'X\x1b\[0m$')
 
     def test_getCellStr_unknown_number_azmode(self):
         g = Game(azmode=True)
@@ -333,10 +363,10 @@ class TestGame(unittest.TestCase):
 
     def test_boardToString_height_no_margins(self):
         s = self.g.boardToString()
-        self.assertEqual(len(s.split("\n")), self.b.size())
+        self.assertEqual(len(s.split("\n")), self.b.height())
 
     # == .__str__ == #
 
     def test_str_height_no_margins(self):
         s = str(self.g)
-        self.assertEqual(len(s.split("\n")), self.b.size())
+        self.assertEqual(len(s.split("\n")), self.b.height())

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -142,7 +142,7 @@ class TestUI(unittest.TestCase):
         else:
             self.assertFalse(True, "should exit after printing the version")
         self.assertEqual(self.exit_status, 0)
-        self.assertRegexpMatches(self.output.read(),
+        self.assertRegex(self.output.read(),
                                  r'^term2048 v\d+\.\d+\.\d+$')
 
     def test_start_game_print_version_over_rules(self):
@@ -154,7 +154,7 @@ class TestUI(unittest.TestCase):
         else:
             self.assertFalse(True, "should exit after printing the version")
         self.assertEqual(self.exit_status, 0)
-        self.assertRegexpMatches(self.output.read(),
+        self.assertRegex(self.output.read(),
                                  r'^term2048 v\d+\.\d+\.\d+$')
 
     def test_start_game_print_rules(self):
@@ -166,7 +166,7 @@ class TestUI(unittest.TestCase):
         else:
             self.assertFalse(True, "should exit after printing the version")
         self.assertEqual(self.exit_status, 0)
-        self.assertRegexpMatches(self.output.read(), r'.+')
+        self.assertRegex(self.output.read(), r'.+')
 
     def test_start_game_loop(self):
         sys.argv = ['term2048']
@@ -181,7 +181,9 @@ class TestUI(unittest.TestCase):
 
         sys.argv = ['term2048']
         g2 = ui.start_game(debug=True)
-        self.assertIn(g2.board.getCell(0, 0), [0, 2, 4])
+        # a fresh board can contain 0, +/-2, +/-4 or a blocker at (0,0) but
+        # never the 16 we stored, since we didn't pass --resume
+        self.assertNotEqual(g2.board.getCell(0, 0), 16)
 
     def test_start_game_resume(self):
         cellvalue = 2


### PR DESCRIPTION
## Add anti-matter tiles, blocker tiles, and rectangular boards

Three new gameplay mechanics in the board engine, with the existing move/merge logic reworked to support them.

### Anti-matter tiles
- A freshly spawned tile has a configurable chance (`antimatter_chance`) of being **negative**.
- Two equal negatives merge into their double (`-2 + -2 = -4`); a tile and its **exact negative annihilate** into an empty cell.
- Rendered in a dedicated color, and as **uppercase letters** in `--azmode`.

### Blocker tiles
- A configurable number of **immovable `X` tiles** placed at game start, on cells that never share a row or column so they can't wall off a region.
- Each line/column is split on its blockers and every segment slides and merges **independently** (tiles can't pass through a blocker).

### Rectangular boards
- The board now takes independent **width and height**. The legacy square `size=` constructor argument and `Board.size()` are kept for backward compatibility.

### Tests
- Adds coverage for annihilation, anti-matter merges, blocker segmentation, rectangular dimensions, and blocker placement.
- Existing board tests are parametrized to opt out of the new mechanics, so the classic behaviour stays covered.
- Full suite (`python tests/test.py`): **132 tests pass**.

### ⚠️ Heads-up on defaults
As written, this branch changes the **default** game (rectangular `8x4` board, `~20%` anti-matter tiles, `2` blockers). That's a deliberate variant, but if you'd rather keep the classic `4x4` / no-blocker / no-anti-matter game as the default, I'm happy to gate all three behind CLI flags (e.g. `--width/--height`, `--blockers N`, `--antimatter`) so they're strictly opt-in. Let me know which you'd prefer and I'll adjust before you merge.
